### PR TITLE
Add registries for ticket adapters and pipes

### DIFF
--- a/src/open_ticket_ai/core/dependency_injection/container.py
+++ b/src/open_ticket_ai/core/dependency_injection/container.py
@@ -8,7 +8,7 @@ from open_ticket_ai.core.config.config_models import (
     OpenTicketAIConfig,
     load_config,
 )
-from open_ticket_ai.core.dependency_injection.registry import TicketSystemRegistry
+from open_ticket_ai.core.dependency_injection.registry import PipeRegistry, TicketSystemRegistry
 from open_ticket_ai.core.pipeline.pipe import Pipe
 from open_ticket_ai.core.pipeline.pipeline import Pipeline
 from open_ticket_ai.core.ticket_system_integration.ticket_system_adapter import TicketSystemAdapter
@@ -40,7 +40,10 @@ class AppModule(Module):
         pipes = []
 
         for pipe_config in config.pipelines[0].steps:
-            pipe_class: type[Pipe] = self._import_pipe_class(pipe_config.type)
+            try:
+                pipe_class: type[Pipe] = PipeRegistry.get(pipe_config.type)
+            except ValueError:
+                pipe_class = self._import_pipe_class(pipe_config.type)
 
             # Get the ConfigT from the Pipe class
             pipe_instance = pipe_class(config=pipe_config, ticket_system=ticket_system_adapter)

--- a/src/open_ticket_ai/core/dependency_injection/registry.py
+++ b/src/open_ticket_ai/core/dependency_injection/registry.py
@@ -1,45 +1,80 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Optional, Type
+from typing import Any, Callable, Dict, Generic, Optional, Type, TypeVar
 
 from open_ticket_ai.core.ticket_system_integration.ticket_system_adapter import TicketSystemAdapter
+from open_ticket_ai.core.pipeline.pipe import Pipe
 
 
-class TicketSystemRegistry[T:TicketSystemAdapter]:
-    _instance: Optional[TicketSystemRegistry] = None
-    _registry: Dict[str, Type[T]] = {}
+T = TypeVar("T")
 
-    def __new__(cls) -> TicketSystemRegistry:
+
+class Registry(Generic[T]):
+    """Generic registry that maps string identifiers to implementation classes."""
+
+    _instance: Optional["Registry[T]"] = None
+    _registry: Dict[str, T] = {}
+
+    def __new__(cls) -> "Registry[T]":
         if cls._instance is None:
             cls._instance = super().__new__(cls)
         return cls._instance
 
     @classmethod
-    def register(cls, system_type: str) -> callable:
+    def register(cls, identifier: str) -> Callable[[T], T]:
+        """Decorator used to register an implementation in the registry."""
 
-        def decorator(adapter_class: Type[T]) -> Type[T]:
-            if system_type in cls._registry:
-                raise ValueError(f"Ticket system '{system_type}' is already registered")
-            cls._registry[system_type] = adapter_class
-            return adapter_class
+        def decorator(implementation: T) -> T:
+            if identifier in cls._registry:
+                raise ValueError(f"'{identifier}' is already registered")
+            cls._registry[identifier] = implementation
+            return implementation
 
         return decorator
 
     @classmethod
-    def create(cls, system_type: str, **kwargs: Any) -> T:
-        if system_type not in cls._registry:
+    def get(cls, identifier: str) -> T:
+        if identifier not in cls._registry:
             raise ValueError(
-                f"Unknown ticket system type: {system_type}. "
-                f"Available types: {list(cls._registry.keys())}"
+                f"Unknown identifier: {identifier}. Available: {list(cls._registry.keys())}"
             )
-        return cls._registry[system_type](**kwargs)
+        return cls._registry[identifier]
 
     @classmethod
-    def get_available_systems(cls) -> Dict[str, Type[T]]:
-        """Get a dictionary of all registered ticket system types and their adapter classes."""
+    def get_available(cls) -> Dict[str, T]:
+        """Get a dictionary of all registered identifiers and their implementations."""
         return cls._registry.copy()
 
     @classmethod
     def clear_registry(cls) -> None:
         """Clear all registered adapters (mainly for testing)."""
         cls._registry.clear()
+
+
+AdapterType = TypeVar("AdapterType", bound=TicketSystemAdapter)
+
+
+class TicketSystemRegistry(Registry[Type[AdapterType]]):
+    _instance: Optional["TicketSystemRegistry[AdapterType]"] = None
+    _registry: Dict[str, Type[AdapterType]] = {}
+
+    @classmethod
+    def create(cls, system_type: str, **kwargs: Any) -> AdapterType:
+        adapter_class = cls.get(system_type)
+        return adapter_class(**kwargs)
+
+    @classmethod
+    def get_available_systems(cls) -> Dict[str, Type[AdapterType]]:
+        return cls.get_available()
+
+
+PipeType = TypeVar("PipeType", bound=Pipe)
+
+
+class PipeRegistry(Registry[Type[PipeType]]):
+    _instance: Optional["PipeRegistry[PipeType]"] = None
+    _registry: Dict[str, Type[PipeType]] = {}
+
+    @classmethod
+    def get_available_pipes(cls) -> Dict[str, Type[PipeType]]:
+        return cls.get_available()

--- a/src/open_ticket_ai/extensions/pipe_implementations/context_modifier.py
+++ b/src/open_ticket_ai/extensions/pipe_implementations/context_modifier.py
@@ -1,9 +1,11 @@
 from typing import Any, Dict
 
+from open_ticket_ai.core.dependency_injection.registry import PipeRegistry
 from open_ticket_ai.core.pipeline.pipe import Pipe
 from open_ticket_ai.extensions.pipe_implementations.pipe_configs import ContextModifierConfig
 
 
+@PipeRegistry.register("open_ticket_ai.extensions.ContextModifier")
 class ContextModifier(Pipe[ContextModifierConfig]):
     """
     A pipe implementation that modifies the pipeline context.

--- a/src/open_ticket_ai/extensions/pipe_implementations/hf_local_ai_inference_service.py
+++ b/src/open_ticket_ai/extensions/pipe_implementations/hf_local_ai_inference_service.py
@@ -3,10 +3,12 @@ import os
 from functools import lru_cache
 from typing import Any, Dict, Optional
 
+from open_ticket_ai.core.dependency_injection.registry import PipeRegistry
 from open_ticket_ai.core.pipeline.pipe import Pipe
 from open_ticket_ai.extensions.pipe_implementations.pipe_configs import HFLocalAIInferenceServiceConfig
 
 
+@PipeRegistry.register("open_ticket_ai.extensions.HFLocalAIInferenceService")
 class HFLocalAIInferenceService(Pipe[HFLocalAIInferenceServiceConfig]):
     ConfigModel = HFLocalAIInferenceServiceConfig
 

--- a/src/open_ticket_ai/extensions/pipe_implementations/simple_key_value_mapper.py
+++ b/src/open_ticket_ai/extensions/pipe_implementations/simple_key_value_mapper.py
@@ -1,5 +1,6 @@
 from typing import Any, Dict, TypeVar
 
+from open_ticket_ai.core.dependency_injection.registry import PipeRegistry
 from open_ticket_ai.core.pipeline.base_pipe_config import BasePipeConfig
 from open_ticket_ai.core.pipeline.pipe import Pipe
 from open_ticket_ai.extensions.pipe_implementations.pipe_configs import SimpleKeyValueMapperConfig
@@ -7,6 +8,7 @@ from open_ticket_ai.extensions.pipe_implementations.pipe_configs import SimpleKe
 ConfigT = TypeVar("ConfigT", bound=BasePipeConfig)
 
 
+@PipeRegistry.register("open_ticket_ai.extensions.SimpleKeyValueMapper")
 class SimpleKeyValueMapper(Pipe[SimpleKeyValueMapperConfig]):
     ConfigModel = SimpleKeyValueMapperConfig
 

--- a/src/open_ticket_ai/extensions/pipe_implementations/ticket_system_service.py
+++ b/src/open_ticket_ai/extensions/pipe_implementations/ticket_system_service.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Any, Dict
 
+from open_ticket_ai.core.dependency_injection.registry import PipeRegistry
 from open_ticket_ai.core.pipeline.base_pipe_state import BasePipeState
 from open_ticket_ai.core.pipeline.pipe import Pipe
 from open_ticket_ai.core.ticket_system_integration.ticket_system_adapter import TicketSystemAdapter
@@ -11,6 +12,7 @@ from open_ticket_ai.core.ticket_system_integration.unified_models import (
 from open_ticket_ai.extensions.pipe_implementations.pipe_configs import TicketSystemServiceConfig
 
 
+@PipeRegistry.register("open_ticket_ai.extensions.TicketSystemService")
 class TicketSystemService(Pipe[TicketSystemServiceConfig, BasePipeState]):
     ConfigModel = TicketSystemServiceConfig
 

--- a/src/open_ticket_ai_otobo_znuny/__init__.py
+++ b/src/open_ticket_ai_otobo_znuny/__init__.py
@@ -1,0 +1,4 @@
+"""OTOBO Znuny plugin for Open Ticket AI."""
+
+# Importing the adapter registers it with the application registries.
+from .otobo_adapter import OTOBOAdapter  # noqa: F401

--- a/src/open_ticket_ai_otobo_znuny/otobo_adapter.py
+++ b/src/open_ticket_ai_otobo_znuny/otobo_adapter.py
@@ -21,7 +21,6 @@ F = TypeVar('F', bound=Callable[..., Any])
 retry_logger = logging.getLogger("tenacity.retry")
 retry_logger.setLevel(logging.WARNING)
 
-from open_ticket_ai.core.config.config_models import OTOBOAdapterConfig
 from open_ticket_ai.core.dependency_injection.registry import TicketSystemRegistry
 from open_ticket_ai.core.ticket_system_integration.ticket_system_adapter import TicketSystemAdapter
 from open_ticket_ai.core.ticket_system_integration.unified_models import (
@@ -31,6 +30,7 @@ from open_ticket_ai.core.ticket_system_integration.unified_models import (
     UnifiedTicketBase,
 )
 from open_ticket_ai_otobo_znuny.models import TicketAdapter
+from open_ticket_ai_otobo_znuny.otobo_adapter_config import OTOBOAdapterConfig
 
 
 def _to_id_name(entity: UnifiedEntity | None) -> IdName | None:
@@ -74,7 +74,7 @@ def otobo_retry() -> Callable[[F], F]:
     return decorator
 
 
-@TicketSystemRegistry.register("OTOBOZnunyTicketSystemService")
+@TicketSystemRegistry.register("otobo")
 class OTOBOAdapter(TicketSystemAdapter):
     @inject
     def __init__(self, config: dict[str, Any]):


### PR DESCRIPTION
## Summary
- introduce a generic registry utility with dedicated ticket-system and pipe registries
- resolve pipeline pipes via the registry and register the built-in implementations
- wire the OTOBO plugin to auto-register its adapter when imported

## Testing
- pytest *(fails: missing test dependencies such as otobo, open_ticket_ai, pydantic, schedule, rich, yaml)*

------
https://chatgpt.com/codex/tasks/task_e_68d85d9c91b48327bac0045a9b13ea14