### PR TITLE
Add tests for base pipe configs and improve rendering logic

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,7 @@
 [pytest]
-pythonpath = .
+pythonpath =
+    .
+    src
 testpaths =
     tests
     open_ticket_ai/tests

--- a/src/open_ticket_ai/core/config/config_models.py
+++ b/src/open_ticket_ai/core/config/config_models.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 import yaml
 from pydantic import BaseModel
@@ -14,6 +14,7 @@ class RenderedSystemConfig(BaseModel):
 
 
 class SystemConfig(RawConfig[RenderedSystemConfig]):
+    rendered_model_type: ClassVar[type[RenderedSystemConfig]] = RenderedSystemConfig
     id: str
     provider_key: str
     config: dict[str, Any] = {}
@@ -31,6 +32,7 @@ class RenderedOpenTicketAIConfig(BaseModel):
 
 
 class OpenTicketAIConfig(RawConfig[RenderedOpenTicketAIConfig]):
+    rendered_model_type: ClassVar[type[RenderedOpenTicketAIConfig]] = RenderedOpenTicketAIConfig
     version: str = "1.0.0"
     plugins: list[str] = []
     general_config: dict[str, Any] = {}

--- a/src/open_ticket_ai/core/config/raw_config.py
+++ b/src/open_ticket_ai/core/config/raw_config.py
@@ -1,10 +1,27 @@
-from typing import Any
+from typing import Any, ClassVar, Generic, TypeVar, cast
 
 from pydantic import BaseModel
 
 from open_ticket_ai.core.config.jinja2_env import render_recursive
 
 
-class RawConfig[RenderedConfig: BaseModel](BaseModel):
-    def render(self, scope: dict[str, Any] | BaseModel) -> RenderedConfig:
-        return render_recursive(self.model_dump(), scope)
+RenderedConfigT = TypeVar("RenderedConfigT", bound=BaseModel)
+
+
+class RawConfig(BaseModel, Generic[RenderedConfigT]):
+    rendered_model_type: ClassVar[type[RenderedConfigT] | None] = None
+
+    def _render_model_dump(self) -> dict[str, Any]:
+        return self.model_dump()
+
+    def _post_render_transform(self, rendered: Any) -> Any:
+        return rendered
+
+    def render(self, scope: dict[str, Any] | BaseModel) -> RenderedConfigT:
+        rendered_data = self._post_render_transform(render_recursive(self._render_model_dump(), scope))
+        rendered_model = self.rendered_model_type
+
+        if rendered_model is not None and not isinstance(rendered_data, rendered_model):
+            return rendered_model.model_validate(rendered_data)
+
+        return cast(RenderedConfigT, rendered_data)

--- a/src/open_ticket_ai/core/pipeline/base_pipe.py
+++ b/src/open_ticket_ai/core/pipeline/base_pipe.py
@@ -47,6 +47,8 @@ class BasePipe[RawConfigT: RawPipeConfig](ABC, TemplateConfiguredClass):
         return typing.cast(type[BasePipe[Any]], self._registry.get_class(pipe_type))
 
     async def process(self, context: PipelineContext) -> PipelineContext:
+        self._current_context = context
+
         if not self.config.when:
             self._logger.info(
                 f"Skipping pipe '{self.config.name}' of type '{self.__class__.__name__}' as 'when' condition is False")

--- a/src/open_ticket_ai/core/pipeline/base_pipe_config.py
+++ b/src/open_ticket_ai/core/pipeline/base_pipe_config.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import enum
-from typing import Self, TypeVar
+from typing import Any, ClassVar, Self, TypeVar
 
 from pydantic import BaseModel, Field
 
@@ -40,4 +40,25 @@ class RenderedPipeConfig(_BasePipeConfig):
 
 
 class RawPipeConfig(RawConfig[RenderedPipeConfig], _BasePipeConfig):
-    pass
+    rendered_model_type: ClassVar[type[RenderedPipeConfig]] = RenderedPipeConfig
+
+    def _render_model_dump(self) -> dict[str, Any]:
+        data = super().model_dump(exclude={"steps"})
+        steps_value = self.steps
+
+        if isinstance(steps_value, list):
+            data["steps"] = list(steps_value)
+        else:
+            data["steps"] = steps_value
+
+        return data
+
+    def _post_render_transform(self, rendered: Any) -> Any:
+        if isinstance(rendered, dict):
+            return {
+                key: value
+                for key, value in rendered.items()
+                if not (key in {"on_failure", "on_success"} and value is None)
+            }
+
+        return rendered

--- a/tests/unit/open_ticket_ai/core/pipeline/test_base_pipe_config.py
+++ b/tests/unit/open_ticket_ai/core/pipeline/test_base_pipe_config.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import asyncio
+import copy
+
+from open_ticket_ai.core.pipeline.base_pipe import BasePipe
+from open_ticket_ai.core.pipeline.base_pipe_config import (
+    OnType,
+    RawPipeConfig,
+    RenderedPipeConfig,
+)
+from open_ticket_ai.core.pipeline.context import PipelineContext
+
+
+class FakeRegistry:
+    def __init__(self, mapping: dict[str, type[BasePipe]]):
+        self._mapping = mapping
+
+    def get_class(self, name: str) -> type[BasePipe]:
+        return self._mapping[name]
+
+
+class TrackingStepPipe(BasePipe[RawPipeConfig]):
+    call_count = 0
+
+    @staticmethod
+    def get_raw_config_model_type() -> type[RawPipeConfig]:
+        return RawPipeConfig
+
+    async def _process(self) -> dict[str, str]:
+        type(self).call_count += 1
+        return {"step": self.config.name}
+
+
+class TrackingMainPipe(BasePipe[RawPipeConfig]):
+    def __init__(self, config: RawPipeConfig, registry: FakeRegistry, result: dict[str, object] | None = None):
+        super().__init__(config=config, registry=registry)
+        self._result = copy.deepcopy(result) if result is not None else {"status": "ok"}
+        self.process_calls = 0
+
+    @staticmethod
+    def get_raw_config_model_type() -> type[RawPipeConfig]:
+        return RawPipeConfig
+
+    async def _process(self) -> dict[str, object]:
+        self.process_calls += 1
+        return copy.deepcopy(self._result)
+
+
+def test_rendered_pipe_config_defaults() -> None:
+    rendered = RenderedPipeConfig(use="ExamplePipe", when=True)
+
+    assert rendered.name == "anonymous"
+    assert rendered.on_failure is OnType.FAIL_CONTAINER
+    assert rendered.on_success is OnType.CONTINUE
+    assert rendered.steps == []
+
+
+def test_raw_pipe_config_renders_to_rendered_model() -> None:
+    raw = RawPipeConfig(
+        name="{{ config['display_name'] }}",
+        use="ExamplePipe",
+        when="{{ config['should_run'] }}",
+        on_failure="{{ 'finish_container' }}",
+        on_success="{{ 'continue' }}",
+        steps=[RawPipeConfig(name="child", use="ExamplePipe", when="True")],
+    )
+
+    context = PipelineContext(config={"display_name": "MainPipe", "should_run": True})
+
+    rendered = raw.render(context)
+
+    assert isinstance(rendered, RenderedPipeConfig)
+    assert rendered.name == "MainPipe"
+    assert rendered.when is True
+    assert rendered.on_failure is OnType.FINISH_CONTAINER
+    assert rendered.on_success is OnType.CONTINUE
+    assert rendered.steps[0].use == "ExamplePipe"
+
+
+def test_pipeline_context_has_distinct_defaults() -> None:
+    first = PipelineContext()
+    second = PipelineContext()
+
+    first.pipes["a"] = {"value": 1}
+    first.config["threshold"] = 10
+
+    assert "a" not in second.pipes
+    assert "threshold" not in second.config
+
+
+def test_base_pipe_process_runs_steps_and_updates_context() -> None:
+    TrackingStepPipe.call_count = 0
+    registry = FakeRegistry({"TrackingStepPipe": TrackingStepPipe})
+
+    step_config = RawPipeConfig(name="child", use="TrackingStepPipe", when="True")
+    main_config = RawPipeConfig(name="parent", use="TrackingMainPipe", when="True", steps=[step_config])
+
+    pipe = TrackingMainPipe(config=main_config, registry=registry, result={"outcome": "success"})
+
+    input_context = PipelineContext()
+    result_context = asyncio.run(pipe.process(input_context))
+
+    assert TrackingStepPipe.call_count == 1
+    assert pipe.process_calls == 1
+    assert result_context is input_context
+    assert result_context.pipes["child"] == {"step": "child"}
+    assert result_context.pipes["parent"] == {"outcome": "success"}
+
+
+def test_base_pipe_process_skips_when_condition_false() -> None:
+    registry = FakeRegistry({})
+    pipe = TrackingMainPipe(
+        config=RawPipeConfig(name="skipped", use="TrackingMainPipe", when="False"),
+        registry=registry,
+    )
+
+    original_context = PipelineContext(pipes={"existing": {"value": 42}})
+    result_context = asyncio.run(pipe.process(original_context))
+
+    assert pipe.process_calls == 0
+    assert result_context is original_context
+    assert result_context.pipes == {"existing": {"value": 42}}


### PR DESCRIPTION
## Summary
- add unit tests covering rendered and raw pipe configs, pipeline context defaults, and base pipe processing
- ensure raw config rendering returns typed models, preserves nested step definitions, and defaults on_success/on_failure properly
- update base pipe to reuse provided context and allow pytest imports via src on sys.path

## Testing
- `pytest tests/unit/open_ticket_ai/core/pipeline/test_base_pipe_config.py`


------
https://chatgpt.com/codex/tasks/task_e_68d998ec310c8327b9159f952437b598