### PR TITLE
Add tests for config models and pipe config classes

### DIFF
--- a/tests/unit/open_ticket_ai/core/config/test_config_classes.py
+++ b/tests/unit/open_ticket_ai/core/config/test_config_classes.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from pydantic import ValidationError
+
+from open_ticket_ai.core.pipeline.configurable_pipe_config import (
+    OnType,
+    RawPipeConfig,
+    RenderedPipeConfig,
+)
+from open_ticket_ai.core.config.registerable_config import RegisterableConfig
+
+
+def test_registerable_config_defaults_are_independent() -> None:
+    first = RegisterableConfig()
+    second = RegisterableConfig()
+
+    assert first.id != second.id
+    assert first.name == ""
+    assert first.when is True
+    assert first.steps == []
+    assert first.use == "open_ticket_ai.base.DefaultPipe"
+
+    first.steps.append({"use": "some.pipe"})
+    assert second.steps == []
+
+    custom = RegisterableConfig(use="collections.Counter")
+    module = importlib.import_module("collections")
+    assert custom.use is module.Counter
+
+
+def test_rendered_pipe_config_requires_boolean_when() -> None:
+    with pytest.raises(ValidationError):
+        RenderedPipeConfig()
+
+    config = RenderedPipeConfig(when=True)
+    assert config.when is True
+    assert config.on_failure is OnType.FAIL_CONTAINER
+    assert config.on_success is OnType.CONTINUE
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("on_failure", "finish_container"),
+        ("on_success", "continue"),
+    ],
+)
+def test_raw_pipe_config_accepts_optional_strings(field: str, value: str) -> None:
+    config = RawPipeConfig(**{field: value})
+    assert getattr(config, field) == value
+    assert config.when == "True"
+
+
+def test_raw_pipe_config_requires_string_when() -> None:
+    with pytest.raises(ValidationError):
+        RawPipeConfig(when=False)

--- a/tests/unit/open_ticket_ai/core/config/test_config_models.py
+++ b/tests/unit/open_ticket_ai/core/config/test_config_models.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from open_ticket_ai.core.config.config_models import RawOpenTicketAIConfig, load_config
+
+
+def test_load_config_parses_expected_structure(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yml"
+    config_path.write_text(
+        """
+        open_ticket_ai:
+          plugins:
+            - plugin_a
+          general_config:
+            service:
+              url: https://example.com
+          defs:
+            - id: def-1
+              value: 42
+          orchestrator:
+            - id: orchestrator-step
+              type: some.pipe
+        """.strip(),
+        encoding="utf-8",
+    )
+
+    config = load_config(config_path)
+
+    assert isinstance(config, RawOpenTicketAIConfig)
+    assert config.plugins == ["plugin_a"]
+    assert config.general_config == {"service": {"url": "https://example.com"}}
+    assert config.defs == [{"id": "def-1", "value": 42}]
+    assert config.orchestrator == [{"id": "orchestrator-step", "type": "some.pipe"}]
+
+
+def test_load_config_missing_root_key(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yml"
+    config_path.write_text("{}", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="open_ticket_ai"):
+        load_config(config_path)
+
+
+def test_raw_open_ticket_ai_config_defaults_are_isolated() -> None:
+    first = RawOpenTicketAIConfig()
+    second = RawOpenTicketAIConfig()
+
+    first.plugins.append("plugin-a")
+    first.general_config["a"] = {"b": 1}
+    first.defs.append({"id": "def"})
+    first.orchestrator.append({"id": "orchestrator"})
+
+    assert second.plugins == []
+    assert second.general_config == {}
+    assert second.defs == []
+    assert second.orchestrator == []


### PR DESCRIPTION
## Summary
- add coverage for loading top-level YAML configs and RawOpenTicketAIConfig defaults
- exercise RegisterableConfig plus rendered and raw pipe config behaviours

## Testing
- pytest tests/unit/open_ticket_ai/core/config -q

------
https://chatgpt.com/codex/tasks/task_e_68dabddbcfc8832790c68766046df6a5