### PR TITLE
Add tests for dependency injection container and unified registry

### DIFF
--- a/tests/unit/open_ticket_ai/core/dependency_injection/test_container.py
+++ b/tests/unit/open_ticket_ai/core/dependency_injection/test_container.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from injector import Injector
+
+from open_ticket_ai.core.config.config_models import RawOpenTicketAIConfig
+from open_ticket_ai.core.dependency_injection import container as container_module
+from open_ticket_ai.core.dependency_injection.container import AppModule
+from open_ticket_ai.core.dependency_injection.instance_creater import InstanceCreator
+from open_ticket_ai.core.dependency_injection.unified_registry import UnifiedRegistry
+
+
+class _SentinelRegistry(UnifiedRegistry):
+    """A registry subclass used to ensure the container binds the expected instance."""
+
+
+def test_app_module_binds_singleton_dependencies(monkeypatch) -> None:
+    fake_config = RawOpenTicketAIConfig()
+    sentinel_registry = _SentinelRegistry()
+    load_config_calls: list[object] = []
+
+    def fake_load_config(path):
+        load_config_calls.append(path)
+        return fake_config
+
+    monkeypatch.setattr(container_module, "load_config", fake_load_config)
+    monkeypatch.setattr(
+        container_module.UnifiedRegistry,
+        "get_registry_instance",
+        classmethod(lambda cls: sentinel_registry),
+    )
+
+    injector = Injector([AppModule()])
+
+    resolved_config = injector.get(RawOpenTicketAIConfig)
+    resolved_registry = injector.get(UnifiedRegistry)
+    resolved_creator = injector.get(InstanceCreator)
+
+    assert load_config_calls == [container_module.CONFIG_PATH]
+    assert resolved_config is fake_config
+    assert resolved_registry is sentinel_registry
+    assert injector.get(RawOpenTicketAIConfig) is resolved_config
+    assert injector.get(UnifiedRegistry) is resolved_registry
+    assert injector.get(InstanceCreator) is resolved_creator
+    assert resolved_creator._config is fake_config  # type: ignore[attr-defined]
+    assert resolved_creator._registry is sentinel_registry  # type: ignore[attr-defined]

--- a/tests/unit/open_ticket_ai/core/dependency_injection/test_unified_registry.py
+++ b/tests/unit/open_ticket_ai/core/dependency_injection/test_unified_registry.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import pytest
+
+from open_ticket_ai.core.dependency_injection.unified_registry import (
+    ConflictingClassRegistration,
+    NotRegistered,
+    UnifiedRegistry,
+)
+
+
+class _DummyService:
+    pass
+
+
+class _AnotherService:
+    pass
+
+
+@pytest.fixture(autouse=True)
+def reset_registry_singleton() -> None:
+    UnifiedRegistry._singleton = None  # type: ignore[attr-defined]
+    yield
+    UnifiedRegistry._singleton = None  # type: ignore[attr-defined]
+
+
+def test_get_registry_instance_returns_singleton() -> None:
+    first = UnifiedRegistry.get_registry_instance()
+    second = UnifiedRegistry.get_registry_instance()
+
+    assert first is second
+
+
+def test_register_and_get_instance_by_class_name() -> None:
+    registry = UnifiedRegistry.get_registry_instance()
+    instance = _DummyService()
+
+    returned = registry.register_instance(instance)
+
+    assert returned is instance
+    assert registry.get_instance("_DummyService") is instance
+
+
+def test_get_instance_raises_not_registered_for_unknown_service() -> None:
+    registry = UnifiedRegistry.get_registry_instance()
+
+    with pytest.raises(NotRegistered) as exc:
+        registry.get_instance("_UnknownService")
+
+    assert "_UnknownService" in str(exc.value)
+
+
+def test_register_instance_raises_for_conflicting_registration() -> None:
+    registry = UnifiedRegistry.get_registry_instance()
+    registry.register_instance(_AnotherService())
+
+    with pytest.raises(ConflictingClassRegistration):
+        registry.register_instance(_AnotherService())


### PR DESCRIPTION
## Summary
- add tests covering unified registry singleton behavior and error cases
- add container tests ensuring singleton bindings and dependencies are provided correctly

## Testing
- pytest tests/unit/open_ticket_ai/core/dependency_injection -q

------
https://chatgpt.com/codex/tasks/task_e_68dabdf90a5c83279d921773159761a8