### PR TITLE
docs: refresh architecture overview

### DIFF
--- a/docs/vitepress_docs/docs_src/de/developers/architecture.md
+++ b/docs/vitepress_docs/docs_src/de/developers/architecture.md
@@ -6,6 +6,45 @@ title: Architekturübersicht von Open Ticket AI
 ---
 # Architekturübersicht
 
-<ClientOnly>
-<ArchitectureOverview></ArchitectureOverview>
-</ClientOnly>
+Open Ticket AI basiert auf einer modularen Ausführungs-Engine, die Support-Tickets über konfigurierbare Pipelines verarbeitet. Jede Pipeline kombiniert wiederverwendbare „Pipes“, die Daten abrufen, Hugging-Face-Modelle ausführen und Ergebnisse zurück in externe Systeme schreiben.
+
+## Systemüberblick
+
+- **Self-Hosted-Kern**: Läuft als Python-Dienst, lädt die Konfiguration, registriert Services und überwacht die Pipeline-Ausführung.
+- **Dependency Injection**: Adapter, Modelle und Hilfsfunktionen werden von einem Inversion-of-Control-Container bereitgestellt, sodass Pipes nur das anfordern, was sie benötigen.
+- **Komponierbare Pipelines**: YAML-Konfigurationen beschreiben, welche Pipes in welcher Reihenfolge laufen und welche `when`-Bedingungen gelten.
+- **Gemeinsamer Ausführungskontext**: Zwischenergebnisse werden in einem Kontextobjekt gespeichert, damit spätere Schritte auf vorherige Ergebnisse zugreifen können, ohne Arbeit zu duplizieren.
+
+## Zentrale Bausteine
+
+### Pipeline-Orchestrator
+Der Orchestrator lädt die aktive Pipeline-Konfiguration, rendert Jinja2-Templates und instanziiert jede Pipe just-in-time. Er beachtet `when`-Bedingungen, iteriert über die Schritte und schreibt den Pipe-Zustand zurück in den gemeinsamen Kontext.
+
+### Pipes
+Pipes kapseln eine Arbeitseinheit – etwa Ticketabruf, Textklassifikation, Metadaten-Aktualisierung oder Telemetrie. Sie sind zwischen den Läufen zustandslos; jede Ausführung erhält frische Eingaben vom Orchestrator und legt ihre Ergebnisse für nachgelagerte Schritte im Kontext ab.
+
+### Services
+Wiederverwendbare Fähigkeiten (HTTP-Clients, Hugging-Face-Pipelines, Speicher-Backends) leben im Service-Container. Pipes fordern Services über `get_instance` an, wodurch Infrastrukturlogik zentralisiert und leicht austauschbar bleibt.
+
+### Ticket-System-Adapter
+Adapter übersetzen zwischen Open Ticket AI und externen Helpdesk-Plattformen. Fetcher-Pipes nutzen einen Adapter, um Tickets zu laden, und Updater-Pipes verwenden denselben Adapter, um Queue-, Prioritäts- oder Kommentaränderungen zurück in das entfernte System zu schreiben.
+
+### Machine-Learning-Modelle
+Vorhersagen für Queue und Priorität stammen aus Hugging-Face-Modellen, die in eigenen Pipes laufen. Diese Pipes befüllen Eingaben aus dem Kontext, führen das Modell aus und ergänzen den Kontext mit strukturierten Vorhersagen für nachfolgende Schritte.
+
+## End-to-End-Verarbeitungsfluss
+
+1. Der Orchestrator initialisiert Services und Ausführungskontext und wählt die konfigurierte Pipeline.
+2. Eine Fetch-Pipe verwendet einen Ticket-System-Adapter, um relevante Tickets abzurufen und im Kontext abzulegen.
+3. Preprocessing-Pipes bereiten den Tickettext für die Modellausführung auf.
+4. Klassifikations-Pipes führen Hugging-Face-Modelle aus, um Queue-, Prioritäts- oder Tag-Vorhersagen zu erzeugen.
+5. Postprocessing-Pipes konsolidieren die Vorhersagen, wenden Geschäftsregeln an und bereiten Update-Payloads vor.
+6. Update-Pipes rufen den Adapter erneut auf, um Ergebnisse (Queue-Wechsel, Prioritätsanpassungen, interne Notizen) auf das ursprüngliche Ticket zu schreiben.
+
+## Erweiterungsmöglichkeiten
+
+- **Neuen Adapter hinzufügen**: Implementieren Sie die Adapter-Schnittstelle für eine weitere Ticketplattform und registrieren Sie sie im Service-Container.
+- **Pipelines anpassen**: Stellen Sie neue Pipe-Kombinationen in YAML zusammen und steuern Sie optionale Schritte mit `when`-Bedingungen.
+- **Neue Intelligenz einbringen**: Ergänzen Sie zusätzliche Modell-Pipes oder regelbasierte Prozessoren, die den gemeinsamen Kontext lesen und schreiben.
+
+Diese Architektur entkoppelt die Klassifikationslogik von den Integrationen und ermöglicht es Teams, den Pipeline-Ablauf an ihre Workflows anzupassen, ohne das Kernlaufzeitsystem ändern zu müssen.

--- a/docs/vitepress_docs/docs_src/en/developers/architecture.md
+++ b/docs/vitepress_docs/docs_src/en/developers/architecture.md
@@ -8,6 +8,45 @@ title: Open Ticket AI Architecture Overview
 ---
 # Architecture Overview
 
-<ClientOnly>
-<ArchitectureOverview></ArchitectureOverview>
-</ClientOnly>
+Open Ticket AI is built around a modular execution engine that processes support tickets through configurable pipelines. Each pipeline combines reusable "pipes" that fetch data, run Hugging Face models, and push results back into external systems.
+
+## System Overview
+
+- **Self-hosted core**: Runs as a Python service that loads configuration, registers services, and supervises pipeline execution.
+- **Dependency-injected services**: Adapters, models, and utilities are provided by an inversion-of-control container so pipes can request only what they need.
+- **Composable pipelines**: YAML configuration describes which pipes run, their order, and any conditional `when` clauses.
+- **Shared execution context**: Intermediate results are stored on a context object so later steps can reuse previous outputs without recomputing work.
+
+## Core Building Blocks
+
+### Pipeline Orchestrator
+The orchestrator loads the active pipeline configuration, renders any Jinja2 templates, and instantiates each pipe just-in-time. It respects `when` conditions, iterates through steps, and persists pipe state back into the shared context.
+
+### Pipes
+Pipes encapsulate a single unit of work—fetching tickets, classifying text, updating metadata, or logging telemetry. They are stateless between runs; every execution receives fresh inputs from the orchestrator and writes results back into the context for downstream steps.
+
+### Services
+Reusable capabilities (HTTP clients, Hugging Face pipelines, storage backends) live in the service container. Pipes request services with `get_instance` so infrastructure code is centralized and easy to swap or extend.
+
+### Ticket System Adapters
+Adapters translate between Open Ticket AI and external helpdesk platforms. Fetcher pipes rely on an adapter to load tickets, while updater pipes use the same adapter to apply queue, priority, or comment changes back to the remote system.
+
+### Machine Learning Models
+Queue and priority predictions are produced by Hugging Face models that run inside dedicated pipes. These pipes hydrate inputs from the context, execute the model, and enrich the context with structured predictions that later pipes consume.
+
+## End-to-End Processing Flow
+
+1. The orchestrator initializes services and the execution context, then selects the configured pipeline.
+2. A fetch pipe uses a ticket system adapter to pull candidate tickets and stores them in the context.
+3. Preprocessing pipes clean and normalize the ticket text for model consumption.
+4. Classification pipes execute Hugging Face models to predict queue assignments, priorities, or tags.
+5. Post-processing pipes consolidate predictions, apply business rules, and prepare update payloads.
+6. Updater pipes call back into the ticket system adapter to write results (queue changes, priority updates, internal notes) to the original ticket.
+
+## Extending the Platform
+
+- **Add a new adapter**: Implement the adapter interface for another ticketing platform and register it in the service container.
+- **Customize pipelines**: Compose new combinations of pipes in YAML, using `when` clauses to guard optional steps.
+- **Introduce new intelligence**: Create additional model pipes or rule-based processors that read from and write to the shared context.
+
+This architecture keeps the classification logic decoupled from integrations, enabling teams to tailor the pipeline to their workflows without modifying the core runtime.

--- a/docs/vitepress_docs/docs_src/es/developers/architecture.md
+++ b/docs/vitepress_docs/docs_src/es/developers/architecture.md
@@ -6,6 +6,45 @@ title: Resumen de la Arquitectura de Open Ticket AI
 ---
 # Resumen de la Arquitectura
 
-<ClientOnly>
-<ArchitectureOverview></ArchitectureOverview>
-</ClientOnly>
+Open Ticket AI se basa en un motor de ejecución modular que procesa los tickets de soporte mediante pipelines configurables. Cada pipeline combina «pipes» reutilizables que recuperan datos, ejecutan modelos de Hugging Face y envían los resultados de vuelta a los sistemas externos.
+
+## Visión general del sistema
+
+- **Núcleo autoalojado**: Se ejecuta como un servicio de Python que carga la configuración, registra los servicios y supervisa la ejecución del pipeline.
+- **Servicios inyectados**: Los adaptadores, modelos y utilidades se proporcionan a través de un contenedor de inversión de control para que cada pipe solicite solo lo que necesita.
+- **Pipelines componibles**: La configuración YAML describe qué pipes se ejecutan, en qué orden y con qué cláusulas condicionales `when`.
+- **Contexto de ejecución compartido**: Los resultados intermedios se guardan en un objeto de contexto, de modo que los pasos posteriores pueden reutilizar salidas previas sin recalcularlas.
+
+## Componentes principales
+
+### Orquestador del pipeline
+El orquestador carga la configuración del pipeline activo, renderiza cualquier plantilla de Jinja2 e instancia cada pipe justo a tiempo. Respeta las condiciones `when`, recorre los pasos y persiste el estado de cada pipe en el contexto compartido.
+
+### Pipes
+Los pipes encapsulan una unidad de trabajo —como recuperar tickets, clasificar texto, actualizar metadatos o registrar telemetría—. Son sin estado entre ejecuciones; cada ejecución recibe entradas nuevas del orquestador y escribe sus resultados en el contexto para los pasos posteriores.
+
+### Servicios
+Las capacidades reutilizables (clientes HTTP, pipelines de Hugging Face, backends de almacenamiento) viven en el contenedor de servicios. Los pipes solicitan servicios con `get_instance`, lo que centraliza la infraestructura y facilita su sustitución o ampliación.
+
+### Adaptadores de sistemas de tickets
+Los adaptadores traducen entre Open Ticket AI y las plataformas de helpdesk externas. Los pipes de obtención utilizan un adaptador para cargar tickets, mientras que los pipes de actualización usan el mismo adaptador para aplicar cambios de cola, prioridad o comentarios en el sistema remoto.
+
+### Modelos de aprendizaje automático
+Las predicciones de cola y prioridad se generan mediante modelos de Hugging Face que se ejecutan en pipes dedicados. Estos pipes alimentan entradas desde el contexto, ejecutan el modelo y enriquecen el contexto con predicciones estructuradas que consumen los pasos siguientes.
+
+## Flujo de procesamiento de extremo a extremo
+
+1. El orquestador inicializa los servicios y el contexto de ejecución y, después, selecciona el pipeline configurado.
+2. Un pipe de obtención utiliza un adaptador de sistema de tickets para recuperar los tickets pertinentes y almacenarlos en el contexto.
+3. Los pipes de preprocesamiento limpian y normalizan el texto del ticket para que lo consuman los modelos.
+4. Los pipes de clasificación ejecutan modelos de Hugging Face para predecir asignaciones de cola, prioridades o etiquetas.
+5. Los pipes de posprocesamiento consolidan las predicciones, aplican reglas de negocio y preparan las cargas útiles de actualización.
+6. Los pipes de actualización vuelven a llamar al adaptador del sistema de tickets para escribir los resultados (cambios de cola, actualizaciones de prioridad, notas internas) en el ticket original.
+
+## Ampliar la plataforma
+
+- **Añadir un nuevo adaptador**: Implemente la interfaz de adaptador para otra plataforma de tickets y regístrela en el contenedor de servicios.
+- **Personalizar los pipelines**: Combine nuevas secuencias de pipes en YAML y utilice cláusulas `when` para controlar los pasos opcionales.
+- **Introducir nueva inteligencia**: Cree pipes de modelos adicionales o procesadores basados en reglas que lean y escriban en el contexto compartido.
+
+Esta arquitectura desacopla la lógica de clasificación de las integraciones, lo que permite a los equipos adaptar el pipeline a sus flujos de trabajo sin modificar el runtime central.

--- a/docs/vitepress_docs/docs_src/fr/developers/architecture.md
+++ b/docs/vitepress_docs/docs_src/fr/developers/architecture.md
@@ -6,6 +6,45 @@ title: Aperçu de l'architecture d'Open Ticket AI
 ---
 # Aperçu de l'architecture
 
-<ClientOnly>
-<ArchitectureOverview></ArchitectureOverview>
-</ClientOnly>
+Open Ticket AI repose sur un moteur d'exécution modulaire qui traite les tickets de support via des pipelines configurables. Chaque pipeline combine des « pipes » réutilisables qui récupèrent les données, exécutent des modèles Hugging Face et renvoient les résultats vers les systèmes externes.
+
+## Vue d'ensemble du système
+
+- **Noyau auto-hébergé** : s'exécute comme un service Python qui charge la configuration, enregistre les services et supervise l'exécution des pipelines.
+- **Services injectés** : adaptateurs, modèles et utilitaires sont fournis par un conteneur d'inversion de contrôle afin que les pipes ne demandent que ce dont ils ont besoin.
+- **Pipelines composables** : la configuration YAML décrit quels pipes s'exécutent, dans quel ordre, ainsi que les clauses conditionnelles `when`.
+- **Contexte partagé d'exécution** : les résultats intermédiaires sont stockés dans un objet de contexte pour que les étapes suivantes puissent réutiliser les sorties précédentes sans recalcul.
+
+## Composants principaux
+
+### Orchestrateur de pipeline
+L'orchestrateur charge la configuration du pipeline actif, rend les modèles Jinja2 et instancie chaque pipe à la volée. Il respecte les conditions `when`, itère sur les étapes et persiste l'état des pipes dans le contexte partagé.
+
+### Pipes
+Les pipes encapsulent une unité de travail — récupération de tickets, classification de texte, mise à jour de métadonnées ou journalisation. Ils sont sans état entre deux exécutions ; chaque run reçoit de nouvelles entrées de l'orchestrateur et écrit ses résultats dans le contexte pour les étapes aval.
+
+### Services
+Les capacités réutilisables (clients HTTP, pipelines Hugging Face, stockages) vivent dans le conteneur de services. Les pipes demandent ces services avec `get_instance`, ce qui centralise l'infrastructure et facilite son remplacement ou son extension.
+
+### Adaptateurs de systèmes de tickets
+Les adaptateurs assurent la traduction entre Open Ticket AI et les plateformes de helpdesk externes. Les pipes de collecte s'appuient sur un adaptateur pour charger les tickets, tandis que les pipes de mise à jour utilisent le même adaptateur pour appliquer les changements de file, de priorité ou de commentaire sur le système distant.
+
+### Modèles de machine learning
+Les prédictions de file et de priorité sont produites par des modèles Hugging Face exécutés dans des pipes dédiés. Ces pipes alimentent les entrées depuis le contexte, exécutent le modèle puis enrichissent le contexte avec des prédictions structurées consommées par les étapes suivantes.
+
+## Flux de traitement de bout en bout
+
+1. L'orchestrateur initialise les services et le contexte d'exécution, puis sélectionne le pipeline configuré.
+2. Un pipe de collecte utilise un adaptateur pour récupérer les tickets concernés et les stocker dans le contexte.
+3. Des pipes de prétraitement nettoient et normalisent le texte du ticket pour la consommation par les modèles.
+4. Des pipes de classification exécutent les modèles Hugging Face pour prédire la file, la priorité ou les étiquettes.
+5. Des pipes de post-traitement consolident les prédictions, appliquent des règles métier et préparent les charges utiles de mise à jour.
+6. Des pipes de mise à jour rappellent l'adaptateur afin d'écrire les résultats (changement de file, de priorité, notes internes) sur le ticket d'origine.
+
+## Étendre la plateforme
+
+- **Ajouter un nouvel adaptateur** : implémentez l'interface d'adaptateur pour une autre plateforme de tickets et enregistrez-la dans le conteneur de services.
+- **Personnaliser les pipelines** : composez de nouvelles combinaisons de pipes en YAML en utilisant des clauses `when` pour piloter les étapes optionnelles.
+- **Introduire de nouvelles intelligences** : créez des pipes de modèles supplémentaires ou des processeurs basés sur des règles qui lisent et écrivent dans le contexte partagé.
+
+Cette architecture découple la logique de classification des intégrations, ce qui permet aux équipes d'adapter le pipeline à leurs flux de travail sans modifier le runtime central.


### PR DESCRIPTION
## Summary
- replace the outdated architecture diagram with prose that explains the modular pipeline engine
- document the key building blocks, execution flow, and extension points for Open Ticket AI
- localize the updated architecture description across English, French, German, and Spanish pages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dabed6cb048327bf0b4af09f347bb2