### PR TITLE
Ensure pipes return structured PipeResult responses

### DIFF
--- a/src/open_ticket_ai/base/jinja_expression_pipe.py
+++ b/src/open_ticket_ai/base/jinja_expression_pipe.py
@@ -3,6 +3,7 @@ from typing import Any
 from pydantic import BaseModel
 
 from open_ticket_ai.core.pipeline.pipe import Pipe
+from open_ticket_ai.core.pipeline.pipe_config import PipeResult
 
 
 class JinjaExpressionPipeConfig(BaseModel):
@@ -15,5 +16,10 @@ class JinjaExpressionPipe(Pipe):
         pipe_config = JinjaExpressionPipeConfig(**config)
         self.expression = pipe_config.expression
 
-    async def _process(self) -> dict[str, Any]:
-        return {"value": self.expression}
+    async def _process(self) -> PipeResult:
+        return PipeResult(
+            success=True,
+            failed=False,
+            message="Expression evaluated successfully",
+            data={"value": self.expression},
+        )

--- a/src/open_ticket_ai/base/ticket_system_pipes/add_note_pipe.py
+++ b/src/open_ticket_ai/base/ticket_system_pipes/add_note_pipe.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel
 
 from open_ticket_ai.core.dependency_injection.unified_registry import UnifiedRegistry
 from open_ticket_ai.core.pipeline.pipe import Pipe
+from open_ticket_ai.core.pipeline.pipe_config import PipeResult
 from open_ticket_ai.core.ticket_system_integration.ticket_system_service import TicketSystemService
 from open_ticket_ai.core.ticket_system_integration.unified_models import UnifiedNote
 
@@ -29,6 +30,11 @@ class AddNotePipe(Pipe):
         else:
             self.note = pipe_config.note
 
-    async def _process(self) -> dict[str, Any]:
+    async def _process(self) -> PipeResult:
         await self.ticket_system.add_note(self.ticket_id, self.note)
-        return {}
+        return PipeResult(
+            success=True,
+            failed=False,
+            message=f"Note added to ticket {self.ticket_id}",
+            data={},
+        )

--- a/src/open_ticket_ai/base/ticket_system_pipes/fetch_tickets_pipe.py
+++ b/src/open_ticket_ai/base/ticket_system_pipes/fetch_tickets_pipe.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel
 
 from open_ticket_ai.core.dependency_injection.unified_registry import UnifiedRegistry
 from open_ticket_ai.core.pipeline.pipe import Pipe
+from open_ticket_ai.core.pipeline.pipe_config import PipeResult
 from open_ticket_ai.core.ticket_system_integration.ticket_system_service import TicketSystemService
 from open_ticket_ai.core.ticket_system_integration.unified_models import TicketSearchCriteria
 
@@ -25,6 +26,13 @@ class FetchTicketsPipe(Pipe):
         else:
             self.search_criteria = pipe_config.ticket_search_criteria
 
-    async def _process(self) -> dict[str, Any]:
+    async def _process(self) -> PipeResult:
         tickets = await self.ticket_system.find_tickets(self.search_criteria) or []
-        return {"found_tickets": [ticket.model_dump() for ticket in tickets]}
+        ticket_payload = {"found_tickets": [ticket.model_dump() for ticket in tickets]}
+        message = f"Fetched {len(ticket_payload['found_tickets'])} ticket(s)"
+        return PipeResult(
+            success=True,
+            failed=False,
+            message=message,
+            data=ticket_payload,
+        )

--- a/src/open_ticket_ai/base/ticket_system_pipes/update_ticket_pipe.py
+++ b/src/open_ticket_ai/base/ticket_system_pipes/update_ticket_pipe.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel
 
 from open_ticket_ai.core.dependency_injection.unified_registry import UnifiedRegistry
 from open_ticket_ai.core.pipeline.pipe import Pipe
+from open_ticket_ai.core.pipeline.pipe_config import PipeResult
 from open_ticket_ai.core.ticket_system_integration.ticket_system_service import TicketSystemService
 from open_ticket_ai.core.ticket_system_integration.unified_models import UnifiedTicket
 
@@ -29,9 +30,14 @@ class UpdateTicketPipe(Pipe):
         else:
             self.updated_ticket = pipe_config.updated_ticket
 
-    async def _process(self) -> dict[str, Any]:
+    async def _process(self) -> PipeResult:
         await self.ticket_system.update_ticket(
             self.ticket_id,
             self.updated_ticket
         )
-        return {}
+        return PipeResult(
+            success=True,
+            failed=False,
+            message=f"Ticket {self.ticket_id} updated",
+            data={},
+        )

--- a/src/open_ticket_ai/core/pipeline/context.py
+++ b/src/open_ticket_ai/core/pipeline/context.py
@@ -7,3 +7,9 @@ from open_ticket_ai.core.pipeline.pipe_config import PipeResult
 class Context(BaseModel):
     pipes: dict[str, PipeResult] = {}
     config: dict[str, Any] = {}
+
+    def has_succeeded(self, pipe_id: str) -> bool:
+        pipe_result = self.pipes.get(pipe_id)
+        if pipe_result is None:
+            return False
+        return pipe_result.success and not pipe_result.failed

--- a/src/open_ticket_ai/hf_local/hf_local_text_classification_pipe.py
+++ b/src/open_ticket_ai/hf_local/hf_local_text_classification_pipe.py
@@ -5,6 +5,7 @@ from typing import Any
 from pydantic import BaseModel
 
 from open_ticket_ai.core.pipeline.pipe import Pipe
+from open_ticket_ai.core.pipeline.pipe_config import PipeResult
 
 
 class HFLocalTextClassificationPipeConfig(BaseModel):
@@ -36,7 +37,7 @@ class HFLocalTextClassificationPipe(Pipe):
         model = AutoModelForSequenceClassification.from_pretrained(model_name, token=token)
         return pipeline("text-classification", model=model, tokenizer=tokenizer)
 
-    async def _process(self) -> dict[str, Any]:
+    async def _process(self) -> PipeResult:
         self.logger.info(f"Running {self.__class__.__name__}")
         if self._pipeline is None:
             self._pipeline = self._load_pipeline(self.model, self.token)
@@ -49,4 +50,9 @@ class HFLocalTextClassificationPipe(Pipe):
 
         self.logger.info(f"Prediction: label {label} with score {score}")
 
-        return {"label": label, "confidence": score}
+        return PipeResult(
+            success=True,
+            failed=False,
+            message="Text classified successfully",
+            data={"label": label, "confidence": score},
+        )

--- a/tests/unit/open_ticket_ai/core/pipeline/test_pipeline.py
+++ b/tests/unit/open_ticket_ai/core/pipeline/test_pipeline.py
@@ -6,6 +6,7 @@ import pytest
 from open_ticket_ai.core.config import jinja2_env
 from open_ticket_ai.core.pipeline.pipe import Pipe
 from open_ticket_ai.core.pipeline.context import Context
+from open_ticket_ai.core.pipeline.pipe_config import PipeResult
 
 
 class DummyChildPipe(Pipe):
@@ -16,25 +17,40 @@ class DummyChildPipe(Pipe):
         self.__class__.processed_contexts.append(context)
         return await super().process(context)
 
-    async def _process(self) -> dict[str, Any]:
+    async def _process(self) -> PipeResult:
         self.__class__.process_count += 1
-        return {"value": self.config.name}
+        return PipeResult(
+            success=True,
+            failed=False,
+            message="Dummy child processed",
+            data={"value": self.config.name},
+        )
 
 
 class DummyParentPipe(Pipe):
-    async def _process(self) -> dict[str, Any]:
-        return {
-            "child_names": list(self._current_context.pipes.keys()),
-            "context_id": id(self._current_context),
-        }
+    async def _process(self) -> PipeResult:
+        return PipeResult(
+            success=True,
+            failed=False,
+            message="Dummy parent processed",
+            data={
+                "child_names": list(self._current_context.pipes.keys()),
+                "context_id": id(self._current_context),
+            },
+        )
 
 
 class SkipPipe(Pipe):
     executed: bool = False
 
-    async def _process(self) -> dict[str, Any]:
+    async def _process(self) -> PipeResult:
         self.__class__.executed = True
-        return {"value": "should not run"}
+        return PipeResult(
+            success=True,
+            failed=False,
+            message="Skip pipe executed",
+            data={"value": "should not run"},
+        )
 
 
 @pytest.fixture(autouse=True)
@@ -90,14 +106,27 @@ async def test_process_executes_child_pipes_and_updates_context(resolve_step_imp
     assert result_context is context
     assert DummyChildPipe.processed_contexts == [context]
     assert DummyChildPipe.process_count == 1
-    assert result_context.pipes["child"] == {"value": "child"}
-    assert result_context.pipes["parent"]["child_names"] == ["child"]
-    assert result_context.pipes["parent"]["context_id"] == id(context)
+    assert result_context.pipes["child"].data == {"value": "child"}
+    assert result_context.pipes["child"].success
+    assert not result_context.pipes["child"].failed
+    assert result_context.pipes["parent"].data["child_names"] == ["child"]
+    assert result_context.pipes["parent"].data["context_id"] == id(context)
+    assert result_context.pipes["parent"].success
 
 
 @pytest.mark.asyncio
 async def test_process_skips_pipe_when_condition_is_false():
-    context = Context(pipes={"existing": {"value": 1}}, config={})
+    context = Context(
+        pipes={
+            "existing": PipeResult(
+                success=True,
+                failed=False,
+                message="Existing pipe",
+                data={"value": 1},
+            )
+        },
+        config={},
+    )
     skip_pipe = SkipPipe({"name": "skip", "when": False})
 
     result_context = await skip_pipe.process(context)


### PR DESCRIPTION
## Summary
- update the base Pipe class to persist and propagate PipeResult objects, including failure handling
- convert all concrete pipe implementations to return PipeResult with meaningful success messages
- adjust pipeline context helpers and unit tests to work with the structured PipeResult payloads

## Testing
- pytest tests/unit/open_ticket_ai/core/pipeline/test_pipeline.py *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68dc06f0e0708327a4cbeed1ce63c375