### PR TITLE
Update pipe result handling in context and tests

### DIFF
--- a/src/open_ticket_ai/core/pipeline/context.py
+++ b/src/open_ticket_ai/core/pipeline/context.py
@@ -1,9 +1,22 @@
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from open_ticket_ai.core.pipeline.pipe_config import PipeResult
 
+
 class Context(BaseModel):
-    pipes: dict[str, PipeResult] = {}
-    config: dict[str, Any] = {}
+    pipes: dict[str, PipeResult] = Field(default_factory=dict)
+    config: dict[str, Any] = Field(default_factory=dict)
+
+    def has_succeeded(self, pipe_id: str) -> bool:
+        result = self.pipes.get(pipe_id)
+        if result is None:
+            return False
+        return result.success
+
+    def has_failed(self, pipe_id: str) -> bool:
+        result = self.pipes.get(pipe_id)
+        if result is None:
+            return False
+        return result.failed

--- a/src/open_ticket_ai/core/pipeline/pipe.py
+++ b/src/open_ticket_ai/core/pipeline/pipe.py
@@ -5,7 +5,7 @@ from abc import abstractmethod
 from typing import Any
 
 from .context import Context
-from .pipe_config import RenderedPipeConfig
+from .pipe_config import PipeResult, RenderedPipeConfig
 from .pipe_factory import PipeFactory
 from ..config.registerable_class import RegisterableClass
 from ..config.registerable_config import RegisterableConfig
@@ -19,7 +19,7 @@ class Pipe(RegisterableClass):
         self._logger = logging.getLogger(self.__class__.__name__)
         self._factory = factory
 
-    def _save_state(self, context: Context, state: dict[str, Any]) -> Context:
+    def _save_state(self, context: Context, state: PipeResult) -> Context:
         context.pipes[self.config.name] = state
         return context
 
@@ -36,12 +36,15 @@ class Pipe(RegisterableClass):
         return context
 
     async def __process_and_safe(self, context: Context) -> Context:
-        new_context = context.model_copy()
+        new_context = context
         try:
-            result = await self._process()
-            new_context = self._save_state(context, result)
+            result_data = await self._process()
+            pipe_result = PipeResult(success=True, failed=False, data=result_data)
+            new_context = self._save_state(context, pipe_result)
         except Exception as e:
             self._logger.error(f"Error in pipe {self.config.name}: {str(e)}", exc_info=True)
+            failure_result = PipeResult(success=False, failed=True, message=str(e), data={})
+            new_context = self._save_state(context, failure_result)
         return new_context
 
     async def _process(self) -> dict[str, Any]:

--- a/src/open_ticket_ai/core/pipeline/pipe_config.py
+++ b/src/open_ticket_ai/core/pipeline/pipe_config.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import enum
 from typing import Any, Self, Iterable
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 from open_ticket_ai.core.config.registerable_config import RegisterableConfig
 
@@ -34,7 +34,7 @@ class PipeResult(BaseModel):
     success: bool
     failed: bool
     message: str = ""
-    data: dict[str, Any] = {}
+    data: dict[str, Any] = Field(default_factory=dict)
 
     def __and__(self, other: Self) -> Self:
         merged_data = {**self.data, **other.data}

--- a/tests/unit/open_ticket_ai/base/ticket_system_pipes/test_fetch_tickets_pipe.py
+++ b/tests/unit/open_ticket_ai/base/ticket_system_pipes/test_fetch_tickets_pipe.py
@@ -87,7 +87,11 @@ def test_process_serializes_results(
         mock_registry.get_instance.assert_called_once_with("test_ticket_system")
 
         state = result_context.pipes["ticket_fetcher"]
-        assert state["found_tickets"] == [ticket.model_dump() for ticket in expected_tickets]
+        assert state.success is True
+        assert state.failed is False
+        assert state.data["found_tickets"] == [
+            ticket.model_dump() for ticket in expected_tickets
+        ]
 
         assert ticket_service.find_tickets.await_count == 1
         args, _ = ticket_service.find_tickets.await_args
@@ -111,4 +115,7 @@ def test_process_without_results_returns_empty_list(
 
         result_context = asyncio.run(pipe.process(pipeline_context))
 
-        assert result_context.pipes["ticket_fetcher"] == {"found_tickets": []}
+        state = result_context.pipes["ticket_fetcher"]
+        assert state.success is True
+        assert state.failed is False
+        assert state.data == {"found_tickets": []}

--- a/tests/unit/open_ticket_ai/core/pipeline/test_pipeline.py
+++ b/tests/unit/open_ticket_ai/core/pipeline/test_pipeline.py
@@ -6,6 +6,7 @@ import pytest
 from open_ticket_ai.core.config import jinja2_env
 from open_ticket_ai.core.pipeline.pipe import Pipe
 from open_ticket_ai.core.pipeline.context import Context
+from open_ticket_ai.core.pipeline.pipe_config import PipeResult
 
 
 class DummyChildPipe(Pipe):
@@ -90,14 +91,27 @@ async def test_process_executes_child_pipes_and_updates_context(resolve_step_imp
     assert result_context is context
     assert DummyChildPipe.processed_contexts == [context]
     assert DummyChildPipe.process_count == 1
-    assert result_context.pipes["child"] == {"value": "child"}
-    assert result_context.pipes["parent"]["child_names"] == ["child"]
-    assert result_context.pipes["parent"]["context_id"] == id(context)
+
+    child_state = result_context.pipes["child"]
+    assert child_state.success is True
+    assert child_state.failed is False
+    assert child_state.data == {"value": "child"}
+
+    parent_state = result_context.pipes["parent"]
+    assert parent_state.success is True
+    assert parent_state.failed is False
+    assert parent_state.data["child_names"] == ["child"]
+    assert parent_state.data["context_id"] == id(context)
 
 
 @pytest.mark.asyncio
 async def test_process_skips_pipe_when_condition_is_false():
-    context = Context(pipes={"existing": {"value": 1}}, config={})
+    context = Context(
+        pipes={
+            "existing": PipeResult(success=True, failed=False, data={"value": 1})
+        },
+        config={},
+    )
     skip_pipe = SkipPipe({"name": "skip", "when": False})
 
     result_context = await skip_pipe.process(context)
@@ -105,3 +119,21 @@ async def test_process_skips_pipe_when_condition_is_false():
     assert result_context is context
     assert "skip" not in context.pipes
     assert not SkipPipe.executed
+
+
+class FailingPipe(Pipe):
+    async def _process(self) -> dict[str, Any]:
+        raise RuntimeError("expected failure")
+
+
+@pytest.mark.asyncio
+async def test_process_records_failure_state():
+    context = Context(pipes={}, config={})
+    failing_pipe = FailingPipe({"name": "fail"})
+
+    result_context = await failing_pipe.process(context)
+
+    failure_state = result_context.pipes["fail"]
+    assert failure_state.success is False
+    assert failure_state.failed is True
+    assert "expected failure" in failure_state.message


### PR DESCRIPTION
## Summary
- ensure pipe contexts store PipeResult instances with success/failed helpers
- wrap pipe execution results in PipeResult objects and record failures with flags
- update pipeline-related tests to assert PipeResult data and add regression coverage for failure states

## Testing
- pytest tests/unit/open_ticket_ai/core/pipeline/test_pipeline.py tests/unit/open_ticket_ai/base/ticket_system_pipes/test_fetch_tickets_pipe.py tests/unit/open_ticket_ai/base/ticket_system_pipes/test_add_note_pipe.py *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68dc06f4b3e08327ae0ca59e81ec8176