### PR TITLE
Fix SonarQube workflow coverage configuration

### DIFF
--- a/.github/workflows/qa-tests.yml
+++ b/.github/workflows/qa-tests.yml
@@ -14,6 +14,15 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+      - name: Install dependencies
+        run: |
+          uv pip install pytest pytest-cov
+          if [ -f requirements.txt ]; then uv pip install -r requirements.txt; fi
+      - name: Run tests with coverage
+        run: |
+          pytest --cov=src --cov-report=xml:coverage.xml
       - name: SonarQube Scan
         uses: SonarSource/sonarqube-scan-action@v6
         env:

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,14 +1,13 @@
 sonar.projectKey=Softoft-Orga_open-ticket-ai
 sonar.organization=softoft-orga
 
-
 # This is the name and version displayed in the SonarCloud UI.
 #sonar.projectName=open-ticket-ai
 #sonar.projectVersion=1.0
 
-
-# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
-#sonar.sources=.
+sonar.sources=src
+sonar.tests=tests
+sonar.python.coverage.reportPaths=coverage.xml
 
 # Encoding of the source code. Default is default system encoding
 #sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
## Summary
- add dependency installation and pytest coverage generation to the SonarQube QA workflow
- configure SonarQube project settings to point at the src and tests directories and consume the coverage report

## Testing
- ❌ `pytest` (fails: ModuleNotFoundError: No module named 'pydantic`)


------
https://chatgpt.com/codex/tasks/task_e_68dc1b10b0088327822685f63e7f3a31