### PR TITLE
Add automation to strip Python comments

### DIFF
--- a/.github/workflows/remove-python-comments.yml
+++ b/.github/workflows/remove-python-comments.yml
@@ -1,0 +1,48 @@
+name: Remove Python comments
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 3 * * 1'
+
+jobs:
+  strip-comments:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Remove Python comments
+        run: python scripts/remove_python_comments.py --root .
+
+      - name: Detect changes
+        id: git-status
+        run: |
+          if git diff --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create Pull Request
+        if: steps.git-status.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: automation/remove-python-comments
+          commit-message: 'chore: remove Python comments'
+          title: 'Remove Python comments'
+          body: |
+            ## Summary
+            - Remove Python comments using `scripts/remove_python_comments.py`
+
+            ## Testing
+            - Workflow run
+          delete-branch: true

--- a/docs/developer_process.md
+++ b/docs/developer_process.md
@@ -1,0 +1,28 @@
+# Developer Process Automation
+
+To keep the repository free from inline Python comments, the project ships with
+an automated cleanup utility and an accompanying GitHub Actions workflow.
+
+## Comment removal script
+
+`scripts/remove_python_comments.py` iterates over all git-tracked `*.py` files
+and rewrites them without `#` style comments. Shebangs and encoding annotations
+are preserved automatically. Run it locally with::
+
+    python scripts/remove_python_comments.py --dry-run
+
+Use the `--dry-run` flag to preview which files would change before applying the
+rewrite.
+
+## Scheduled workflow
+
+The `.github/workflows/remove-python-comments.yml` workflow executes on a weekly
+schedule (and is also available via the "Run workflow" button). It:
+
+1. Checks out the repository and sets up Python.
+2. Runs the comment removal script.
+3. Creates a pull request with the sanitized files using the
+   `peter-evans/create-pull-request` action.
+
+If no files need to be updated the workflow simply exits without creating a
+pull request.

--- a/scripts/remove_python_comments.py
+++ b/scripts/remove_python_comments.py
@@ -1,0 +1,150 @@
+"""Remove comment tokens from git-tracked Python files.
+
+This utility is intended to be run in automated contexts (for example GitHub
+Actions) to ensure the code base does not contain ``#`` style Python comments.
+It preserves file encodings, docstrings, shebang lines, and encoding
+annotations while stripping standalone and inline comments.
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+import tokenize
+
+
+@dataclass
+class FileChange:
+    """Representation of a Python file rewritten by the tool."""
+
+    path: Path
+    updated_source: str
+    encoding: str
+
+    def apply(self) -> None:
+        self.path.write_text(self.updated_source, encoding=self.encoding)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path.cwd(),
+        help="Repository root. Defaults to the current working directory.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="List files that would be changed without rewriting them.",
+    )
+    return parser.parse_args(argv)
+
+
+def list_tracked_python_files(root: Path) -> Iterable[Path]:
+    result = subprocess.run(
+        ["git", "ls-files", "*.py"],
+        cwd=root,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    for line in result.stdout.splitlines():
+        if line.strip():
+            yield root / line.strip()
+
+
+def should_preserve_comment(token: tokenize.TokenInfo) -> bool:
+    text = token.string
+    line_no = token.start[0]
+
+    if line_no == 1 and text.startswith("#!"):
+        return True
+
+    if line_no in (1, 2) and "coding" in text.lower():
+        return True
+
+    return False
+
+
+def strip_comments(source_bytes: bytes) -> tuple[str, str]:
+    """Return the rewritten source and detected encoding."""
+
+    stream = io.BytesIO(source_bytes)
+    encoding, _ = tokenize.detect_encoding(stream.readline)
+    stream.seek(0)
+
+    tokens = tokenize.tokenize(stream.readline)
+    filtered_tokens: list[tokenize.TokenInfo] = []
+
+    for token in tokens:
+        if token.type == tokenize.COMMENT and not should_preserve_comment(token):
+            continue
+        filtered_tokens.append(token)
+
+    rebuilt = tokenize.untokenize(filtered_tokens)
+    if isinstance(rebuilt, bytes):
+        rebuilt_text = rebuilt.decode(encoding)
+    else:
+        rebuilt_text = rebuilt
+    return rebuilt_text, encoding
+
+
+def ensure_trailing_newline(text: str) -> str:
+    return text if text.endswith("\n") else text + "\n"
+
+
+def collect_changes(files: Iterable[Path]) -> list[FileChange]:
+    changes: list[FileChange] = []
+    for path in files:
+        original_bytes = path.read_bytes()
+        rewritten, encoding = strip_comments(original_bytes)
+        original_text = original_bytes.decode(encoding)
+
+        normalized_original = ensure_trailing_newline(original_text)
+        normalized_rewritten = ensure_trailing_newline(rewritten)
+
+        if normalized_rewritten != normalized_original:
+            changes.append(
+                FileChange(
+                    path=path,
+                    updated_source=normalized_rewritten,
+                    encoding=encoding,
+                )
+            )
+    return changes
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    root = args.root.resolve()
+
+    python_files = list(list_tracked_python_files(root))
+    if not python_files:
+        print("No Python files detected.")
+        return 0
+
+    changes = collect_changes(python_files)
+    if not changes:
+        print("No comments found to remove.")
+        return 0
+
+    if args.dry_run:
+        print("Files that would be rewritten:")
+        for change in changes:
+            print(f" - {change.path.relative_to(root)}")
+        return 0
+
+    for change in changes:
+        change.apply()
+        print(f"Rewrote {change.path.relative_to(root)}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a repository utility that rewrites git-tracked Python files without inline comments
- schedule a workflow that runs the remover and opens an automation pull request when changes exist
- document the automation steps for contributors in `docs/developer_process.md`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68dcf00e487c8327a4db059363ec656b