### PR TITLE
Add orchestrator scheduling with runner threads

### DIFF
--- a/src/config.schema.json
+++ b/src/config.schema.json
@@ -78,14 +78,33 @@
         "orchestrator": {
           "anyOf": [
             {
-              "additionalProperties": true,
-              "type": "object"
+              "items": {
+                "additionalProperties": true,
+                "properties": {
+                  "pipe": {
+                    "additionalProperties": true,
+                    "title": "Pipe",
+                    "type": "object"
+                  },
+                  "run_every_milli_seconds": {
+                    "minimum": 1,
+                    "title": "Run Every Milli Seconds",
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "run_every_milli_seconds",
+                  "pipe"
+                ],
+                "type": "object"
+              },
+              "type": "array"
             },
             {
               "type": "string"
             }
           ],
-          "default": {},
+          "default": [],
           "title": "Orchestrator"
         }
       },

--- a/src/open_ticket_ai/config.schema.json
+++ b/src/open_ticket_ai/config.schema.json
@@ -37,6 +37,22 @@
           "default": [],
           "items": {
             "additionalProperties": true,
+            "properties": {
+              "pipe": {
+                "additionalProperties": true,
+                "title": "Pipe",
+                "type": "object"
+              },
+              "run_every_milli_seconds": {
+                "minimum": 1,
+                "title": "Run Every Milli Seconds",
+                "type": "integer"
+              }
+            },
+            "required": [
+              "run_every_milli_seconds",
+              "pipe"
+            ],
             "type": "object"
           },
           "title": "Orchestrator",

--- a/src/open_ticket_ai/core/pipeline/__init__.py
+++ b/src/open_ticket_ai/core/pipeline/__init__.py
@@ -1,0 +1,12 @@
+from .context import Context
+from .orchestrator import Orchestrator
+from .orchestrator_config import OrchestratorConfig, RunnerDefinition
+from .scheduled_runner import ScheduledPipeRunner
+
+__all__ = [
+    "Context",
+    "Orchestrator",
+    "OrchestratorConfig",
+    "RunnerDefinition",
+    "ScheduledPipeRunner",
+]

--- a/src/open_ticket_ai/core/pipeline/orchestrator.py
+++ b/src/open_ticket_ai/core/pipeline/orchestrator.py
@@ -1,3 +1,66 @@
+from __future__ import annotations
+
+import logging
+import threading
+
+from injector import inject
+
+from open_ticket_ai.core.config.config_models import RawOpenTicketAIConfig
+
+from .orchestrator_config import OrchestratorConfig, RunnerDefinition
+from .pipe_factory import PipeFactory
+from .scheduled_runner import ScheduledPipeRunner
+
+
 class Orchestrator:
-    def __init__(self) -> None:
-        pass
+    """Launches scheduled runners for configured pipelines."""
+
+    @inject
+    def __init__(self, pipe_factory: PipeFactory, app_config: RawOpenTicketAIConfig) -> None:
+        self._pipe_factory = pipe_factory
+        self._config = OrchestratorConfig.from_raw(app_config.orchestrator)
+        self._logger = logging.getLogger(self.__class__.__name__)
+        self._runner_threads: list[threading.Thread] = []
+        self._runners: list[ScheduledPipeRunner] = []
+        self._running = False
+
+    def _create_runner(self, definition: RunnerDefinition) -> ScheduledPipeRunner:
+        return ScheduledPipeRunner(definition, self._pipe_factory)
+
+    def run(self) -> None:
+        """Start all configured runners in dedicated daemon threads."""
+        if self._running:
+            self._logger.debug("Orchestrator already running")
+            return
+
+        self._logger.info("Starting orchestrator with %d runner(s)", len(self._config.runners))
+        self._runner_threads.clear()
+        self._runners.clear()
+
+        for index, definition in enumerate(self._config.runners):
+            runner = self._create_runner(definition)
+            thread_name = f"ScheduledPipeRunner-{definition.pipe_id}-{index}"
+            thread = threading.Thread(target=runner.run, name=thread_name, daemon=True)
+            thread.start()
+            self._logger.debug("Started runner thread %s", thread_name)
+            self._runner_threads.append(thread)
+            self._runners.append(runner)
+
+        self._running = True
+
+    def stop(self) -> None:
+        """Stop all running runners and wait for their threads to finish."""
+        if not self._running:
+            self._logger.debug("Orchestrator stop requested but it is not running")
+            return
+
+        self._logger.info("Stopping orchestrator")
+        for runner in self._runners:
+            runner.stop()
+
+        for thread in self._runner_threads:
+            thread.join()
+
+        self._runner_threads.clear()
+        self._runners.clear()
+        self._running = False

--- a/src/open_ticket_ai/core/pipeline/orchestrator_config.py
+++ b/src/open_ticket_ai/core/pipeline/orchestrator_config.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class RunnerDefinition(BaseModel):
+    """Configuration for a scheduled pipeline runner."""
+
+    run_every_milli_seconds: int = Field(..., ge=1)
+    pipe: dict[str, Any] = Field(default_factory=dict)
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    @property
+    def interval_seconds(self) -> float:
+        """Return the configured interval as seconds."""
+        return self.run_every_milli_seconds / 1000.0
+
+    @property
+    def pipe_id(self) -> str:
+        """Return the configured pipe identifier if available."""
+        pipe_id = self.pipe.get("id")
+        if pipe_id:
+            return str(pipe_id)
+        return "pipe"
+
+
+class OrchestratorConfig(BaseModel):
+    """Typed representation of orchestrator configuration entries."""
+
+    runners: list[RunnerDefinition] = Field(default_factory=list)
+
+    @classmethod
+    def from_raw(cls, raw_config: Iterable[dict[str, Any]] | None) -> "OrchestratorConfig":
+        if not raw_config:
+            return cls()
+        runners = [RunnerDefinition.model_validate(entry) for entry in raw_config]
+        return cls(runners=runners)

--- a/src/open_ticket_ai/core/pipeline/scheduled_runner.py
+++ b/src/open_ticket_ai/core/pipeline/scheduled_runner.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+from copy import deepcopy
+
+from injector import inject
+
+from open_ticket_ai.core.pipeline.context import Context
+from open_ticket_ai.core.pipeline.pipe_factory import PipeFactory
+
+from .orchestrator_config import RunnerDefinition
+
+
+class ScheduledPipeRunner:
+    """Continuously executes a configured pipe on a fixed interval."""
+
+    @inject
+    def __init__(self, definition: RunnerDefinition, pipe_factory: PipeFactory):
+        self._definition = definition
+        self._pipe_factory = pipe_factory
+        self._stop_event = threading.Event()
+        self._logger = logging.getLogger(self.__class__.__name__)
+
+    @property
+    def definition(self) -> RunnerDefinition:
+        return self._definition
+
+    def stop(self) -> None:
+        """Signal the runner to stop after the current iteration."""
+        self._stop_event.set()
+
+    def _build_context(self) -> Context:
+        return Context(config=deepcopy(self._definition.pipe))
+
+    def _create_pipe(self, context: Context):
+        return self._pipe_factory.create_pipe({}, deepcopy(self._definition.pipe), context.model_dump())
+
+    def run(self) -> None:
+        """Run the configured pipe until :py:meth:`stop` is called."""
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            while not self._stop_event.is_set():
+                context = self._build_context()
+                try:
+                    pipe = self._create_pipe(context)
+                    loop.run_until_complete(pipe.process(context))
+                except Exception:  # pragma: no cover - defensive programming
+                    self._logger.exception("Pipe execution failed")
+                interval = self._definition.interval_seconds
+                if interval <= 0:
+                    continue
+                if self._stop_event.wait(interval):
+                    break
+        finally:
+            asyncio.set_event_loop(None)
+            loop.close()

--- a/tests/unit/open_ticket_ai/core/test_orchestrator.py
+++ b/tests/unit/open_ticket_ai/core/test_orchestrator.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import threading
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from open_ticket_ai.core.config.config_models import RawOpenTicketAIConfig
+from open_ticket_ai.core.pipeline import (
+    Orchestrator,
+    OrchestratorConfig,
+    RunnerDefinition,
+    ScheduledPipeRunner,
+)
+from open_ticket_ai.core.pipeline.context import Context
+
+
+def test_orchestrator_config_from_raw() -> None:
+    raw = [
+        {
+            "run_every_milli_seconds": 1000,
+            "pipe": {"id": "demo"},
+        }
+    ]
+
+    config = OrchestratorConfig.from_raw(raw)
+
+    assert len(config.runners) == 1
+    assert config.runners[0].pipe["id"] == "demo"
+    assert config.runners[0].interval_seconds == 1.0
+
+
+def test_scheduled_pipe_runner_executes_pipe_until_stopped() -> None:
+    definition = RunnerDefinition(run_every_milli_seconds=10, pipe={"id": "demo"})
+    pipe_factory = MagicMock()
+    process_mock = AsyncMock(return_value=Context())
+    pipe_factory.create_pipe.return_value = SimpleNamespace(process=process_mock)
+
+    runner = ScheduledPipeRunner(definition, pipe_factory)
+
+    thread = threading.Thread(target=runner.run, daemon=True)
+    thread.start()
+
+    try:
+        time.sleep(0.05)
+    finally:
+        runner.stop()
+        thread.join(timeout=1)
+
+    assert not thread.is_alive()
+    assert pipe_factory.create_pipe.call_count >= 1
+    assert process_mock.await_count >= 1
+
+
+def test_orchestrator_starts_and_stops_runners() -> None:
+    config = RawOpenTicketAIConfig(
+        orchestrator=[{"run_every_milli_seconds": 10, "pipe": {"id": "demo"}}]
+    )
+    pipe_factory = MagicMock()
+    process_mock = AsyncMock(return_value=Context())
+    pipe_factory.create_pipe.return_value = SimpleNamespace(process=process_mock)
+
+    orchestrator = Orchestrator(pipe_factory, config)
+
+    orchestrator.run()
+    try:
+        time.sleep(0.05)
+    finally:
+        orchestrator.stop()
+
+    assert pipe_factory.create_pipe.call_count >= 1
+    assert process_mock.await_count >= 1


### PR DESCRIPTION
## Summary
- add typed orchestrator configuration models for orchestrator entries
- implement a scheduled pipe runner and orchestrator thread management
- expose the orchestrator API, update schemas, and cover with unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd5494fb088327ba7d21fd23f4a56b